### PR TITLE
Add links to additional compatible BTUs.

### DIFF
--- a/hardware/mechanicals-btu-mod/readme.md
+++ b/hardware/mechanicals-btu-mod/readme.md
@@ -1,12 +1,16 @@
 ## Ploopy Adept BTU Mod by bomtarnes ([keyboard-magpie](https://github.com/keyboard-magpie/))
-Included are two print files- 
+
+Included are two print files-
 
  - adept-btu-plate.3mf - this includes an integrated support enforcer- I recommend organic supports and "for support enforcers only in prusaslicer
  - adept-btu-top-v1.stl - old fashioned STL for doing as you wish with
 
 Also included is a step file, and a fusion 360 export (my CAD is all self taught and very messy, timeline wise, sorry).
 
-The intended BTUs for v1 are [these veichu ones](https://www.aliexpress.com/item/1005003066404497.html) in 7.5 size.
+The following 7.5mm diameter BTUs are compatibles with this mod:
+* [Veichu 7.5 BTUs](https://www.aliexpress.com/item/1005003066404497.html)
+* [MiSUMi BCHA7.5 - Stainless Steel Main Ball](https://us.misumi-ec.com/vona2/detail/110300427030/?ProductCode=BCHA7.5)
+* [MiSUMi BCHAJ7.5 - POM Main Ball](https://us.misumi-ec.com/vona2/detail/110300427030/?ProductCode=BCHAJ7.5)
 
 I am actively working on other versions for other BTU varieties and will aim to add these in the future.
 


### PR DESCRIPTION
I printed this mod and originally ordered the Ali Express BTUs for it. Unfortunately, the quality control with the Ali Express BTUs I found to be lacking, with 2 of the 3 BTUs being very scratchy (potentially rusted internally). I may have just gotten unlucky, but decided to search for another compatible BTU. I came across these MiSUMi-brand BTUs and ordered them. They are definitely more expensive, but they seem to be of higher quality than the ones from Ali Express and are working wonderfully for me. They are exactly the same size as the Ali Express BTUs, so they are fully compatible with this mod.

Side note — I wish that the BTUs were a bit bigger, as it does not roll as effortlessly as I would like. I'm tempted to order the 9mm or 11mm diameter BTUs from MiSUMi, update the model, re-print the top, and see if that has a meaningful impact on rolling efficiency. If I end up doing that, I'll open a pull request!

Thanks for the wonderful trackball and the original mod!